### PR TITLE
S7-179 enable watchdog

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -27,6 +27,9 @@ void init(void) {
         init_timer();
     }
 
+    // Start housekeeping
+    house_keeping(true);
+
     // Init everything irrigation related 
     init_irrigation();
 
@@ -48,8 +51,9 @@ int main() {
     init();
 
     while (true) {
+        house_keeping(false);
         develop_test();
-        sleep_ms(1000);
+        sleep_ms(100);
 
     }
     return 0;

--- a/app/main.c
+++ b/app/main.c
@@ -36,7 +36,7 @@ void init(void) {
     // Init every thing energy related
     init_energy_management();
 
-    develop_test();
+    // develop_test();
 
     // Get weather data
     // printf("\n-------- Getting weather data\n");
@@ -48,7 +48,7 @@ int main() {
     init();
 
     while (true) {
-        //develop_test();
+        develop_test();
         sleep_ms(1000);
 
     }

--- a/app/utils/CMakeLists.txt
+++ b/app/utils/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(utils
         irrigation
         pv_management
         energy_management
+        sensors
         )
 
 target_include_directories(utils PUBLIC

--- a/app/utils/test.c
+++ b/app/utils/test.c
@@ -4,7 +4,10 @@ void develop_test(void)
 {
     printf("TEST\n");
     // Add function to test here
-    SHT_measure_t meas = read_temp_humidity();
-    printf("\nAir Temperature under panel (Celsius): %f",meas.temp);
-    printf("\nAir Humidity under panel (%): %f", meas.humidity);
+    static uint16_t i = 0;
+    if (i++ == 12) {
+        while (true) {
+            tight_loop_contents();
+        }
+    }
 }

--- a/app/utils/test.c
+++ b/app/utils/test.c
@@ -4,4 +4,7 @@ void develop_test(void)
 {
     printf("TEST\n");
     // Add function to test here
+    SHT_measure_t meas = read_temp_humidity();
+    printf("\nAir Temperature under panel (Celsius): %f",meas.temp);
+    printf("\nAir Humidity under panel (%): %f", meas.humidity);
 }

--- a/app/utils/test.c
+++ b/app/utils/test.c
@@ -4,10 +4,4 @@ void develop_test(void)
 {
     printf("TEST\n");
     // Add function to test here
-    static uint16_t i = 0;
-    if (i++ == 12) {
-        while (true) {
-            tight_loop_contents();
-        }
-    }
 }

--- a/app/utils/test.h
+++ b/app/utils/test.h
@@ -4,6 +4,7 @@
 #include "irrigation.h"
 #include "pv_management.h"
 #include "energy_management.h"
+#include "sensors.h"
 
 /*! \brief For testing and debugging purpose. Put anything you want in this
  *

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -15,7 +15,7 @@ add_subdirectory(wrap_I2C)
 add_subdirectory(wrap_NTP)
 add_subdirectory(wrap_PWM)
 add_subdirectory(wrap_RTC)
-# add_subdirectory(wrap_WATCHDOG)
+add_subdirectory(wrap_WATCHDOG)
 add_subdirectory(wrap_WIFI)
 
 

--- a/driver/SHT/SHT.c
+++ b/driver/SHT/SHT.c
@@ -1,23 +1,40 @@
 #include "SHT.h"
 
 const absolute_time_t ABSOLUTE_TIME_INITIALIZED_VAR(SHT_i2c_timeout, 10000); // 10 ms
-#define STH1_BUF_LEN 4
+// #define STH1_BUF_LEN 4
+#define STH3_BUF_LEN 6
 
 SHT_status_t SHT3_read_temp_humidity(float* temp, float* humidity) {
     SHT_status_t rv = SHT_ok;
 
+    uint8_t buffer[] = {HIGH_REPEATABILITY_NCS, NO_CLOCK_STRECHING};
+    if (i2c0_write(SHT3_address, buffer, sizeof(buffer)) != sizeof(buffer)) {
+        rv = SHT_error;
+    }
+    sleep_ms(15);
+    uint8_t recept[STH3_BUF_LEN];
+    if (i2c0_read(SHT3_address, recept, STH3_BUF_LEN) != STH3_BUF_LEN) {
+        rv = SHT_error;
+    }
+
+    float cTemp = ((((recept[0] * 256.0) + recept[1]) * 175) / 65535.0) - 45;
+    *temp = (cTemp * 1.8) + 32;
+    *humidity = ((((recept[3] * 256.0) + recept[4]) * 100) / 65535.0);
+    // printf("\nAir Temperature under panel (Celsius): %f",cTemp);
+    // printf("\nAir Humidity under panel (%): %f",humidity);
+
     return rv;
 }
 
-SHT_status_t SHT1_read_temp_humidity(float* temp, float* humidity) {
-    SHT_status_t rv = SHT_ok;
-    // Read temperature
-    uint8_t raw_temp[STH1_BUF_LEN];
-    i2c0_read(0x03, raw_temp, (size_t)STH1_BUF_LEN);
+// SHT_status_t SHT1_read_temp_humidity(float* temp, float* humidity) {
+//     SHT_status_t rv = SHT_ok;
+//     // Read temperature
+//     uint8_t raw_temp[STH1_BUF_LEN];
+//     i2c0_read(0x03, raw_temp, (size_t)STH1_BUF_LEN);
 
-    // Read humidity
-    uint8_t raw_humidity[STH1_BUF_LEN];
-    i2c0_read(0x03, raw_humidity, (size_t)STH1_BUF_LEN);
+//     // Read humidity
+//     uint8_t raw_humidity[STH1_BUF_LEN];
+//     i2c0_read(0x03, raw_humidity, (size_t)STH1_BUF_LEN);
 
-    return rv;
-}
+//     return rv;
+// }

--- a/driver/SHT/SHT.c
+++ b/driver/SHT/SHT.c
@@ -1,6 +1,5 @@
 #include "SHT.h"
 
-const absolute_time_t ABSOLUTE_TIME_INITIALIZED_VAR(SHT_i2c_timeout, 10000); // 10 ms
 // #define STH1_BUF_LEN 4
 #define STH3_BUF_LEN 6
 
@@ -11,7 +10,7 @@ SHT_status_t SHT3_read_temp_humidity(float* temp, float* humidity) {
     if (i2c0_write(SHT3_address, buffer, sizeof(buffer)) != sizeof(buffer)) {
         rv = SHT_error;
     }
-    sleep_ms(15);
+    sleep_ms(15); // Based on max measure time in datasheet
     uint8_t recept[STH3_BUF_LEN];
     if (i2c0_read(SHT3_address, recept, STH3_BUF_LEN) != STH3_BUF_LEN) {
         rv = SHT_error;
@@ -20,8 +19,6 @@ SHT_status_t SHT3_read_temp_humidity(float* temp, float* humidity) {
     float cTemp = ((((recept[0] * 256.0) + recept[1]) * 175) / 65535.0) - 45;
     *temp = (cTemp * 1.8) + 32;
     *humidity = ((((recept[3] * 256.0) + recept[4]) * 100) / 65535.0);
-    // printf("\nAir Temperature under panel (Celsius): %f",cTemp);
-    // printf("\nAir Humidity under panel (%): %f",humidity);
 
     return rv;
 }

--- a/driver/SHT/SHT.h
+++ b/driver/SHT/SHT.h
@@ -6,7 +6,23 @@
 #include "wrap_I2C.h"
 
 #define SHT3_address (0x44)
-#define SHT1_address (0x00)
+// #define SHT1_address (0x00)
+
+#define CLOCK_STRECHING           (0x2C)
+#define HIGH_REPEATABILITY_CS     (0x06)
+#define MEDIUM_REPEATABILITY_CS   (0x0D)
+#define LOW_REPEATABILITY_CS      (0x10)
+
+#define NO_CLOCK_STRECHING        (0x24)
+#define HIGH_REPEATABILITY_NCS    (0x00)
+#define MEDUIM_REPEATABILITY_NCS  (0x0B)
+#define LOW_REPEATABILITY_NCS     (0x16)
+
+typedef struct _SHT_measure_t {
+  float humidity;
+  float temp;
+  bool meas_ok;
+} SHT_measure_t;
 
 typedef enum _SHT_status_t{
   SHT_ok,
@@ -14,7 +30,13 @@ typedef enum _SHT_status_t{
   SHT_error
 } SHT_status_t;
 
+/*! \brief Read SHT30 temperature and humidity
+ *
+ * \param temp float to store the converted temperature
+ * \param humidity float to store the converted humdity
+ * \return SHT_ok if everything good, SHT_error if other errors
+ */
 SHT_status_t SHT3_read_temp_humidity(float* temp, float* humidity);
-SHT_status_t SHT1_read_temp_humidity(float* temp, float* humidity);
+// SHT_status_t SHT1_read_temp_humidity(float* temp, float* humidity);
 
 #endif

--- a/driver/wrap_WATCHDOG/CMakeLists.txt
+++ b/driver/wrap_WATCHDOG/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(wrap_WATCHDOG
+        wrap_WATCHDOG.c
+        )
+
+target_link_libraries(wrap_WATCHDOG
+        pico_stdlib              # for core functionality
+        )
+
+target_include_directories(wrap_WATCHDOG PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+        )
+

--- a/driver/wrap_WATCHDOG/wrap_WATCHDOG.c
+++ b/driver/wrap_WATCHDOG/wrap_WATCHDOG.c
@@ -1,0 +1,18 @@
+#include "wrap_WATCHDOG.h"
+
+#define WATCHDOG_TIMEOUT_MS 200
+
+void init_watchdog(void)
+{
+    if (watchdog_caused_reboot()) {
+        printf("Watchdog reboot!\n");
+    }
+
+    watchdog_enable(WATCHDOG_TIMEOUT_MS, 1);
+    printf("Watchdog enabled!\n");
+}
+
+void feed_watchdog(void)
+{
+    watchdog_update();
+}

--- a/driver/wrap_WATCHDOG/wrap_WATCHDOG.c
+++ b/driver/wrap_WATCHDOG/wrap_WATCHDOG.c
@@ -2,10 +2,13 @@
 
 #define WATCHDOG_TIMEOUT_MS 200
 
+static bool reboot_by_watchdog = false;
+
 void init_watchdog(void)
 {
     if (watchdog_caused_reboot()) {
-        printf("Watchdog reboot!\n");
+        reboot_by_watchdog = true;
+        printf("Reboot by watchdog!\n");
     }
 
     watchdog_enable(WATCHDOG_TIMEOUT_MS, 1);

--- a/driver/wrap_WATCHDOG/wrap_WATCHDOG.h
+++ b/driver/wrap_WATCHDOG/wrap_WATCHDOG.h
@@ -5,8 +5,12 @@
 #include "pico/stdlib.h"
 #include "hardware/watchdog.h"
 
-
+/*! \brief Init the watchdog peripheral
+ */
 void init_watchdog(void);
+
+/*! \brief Update the watchdog so it doesn't reboot
+ */
 void feed_watchdog(void);
 
 #endif

--- a/driver/wrap_WATCHDOG/wrap_WATCHDOG.h
+++ b/driver/wrap_WATCHDOG/wrap_WATCHDOG.h
@@ -1,0 +1,12 @@
+#ifndef WRAP_WATCHDOG_H
+#define WRAP_WATCHDOG_H
+
+#include <stdio.h>
+#include "pico/stdlib.h"
+#include "hardware/watchdog.h"
+
+
+void init_watchdog(void);
+void feed_watchdog(void);
+
+#endif

--- a/hal/interface/interface.h
+++ b/hal/interface/interface.h
@@ -11,7 +11,17 @@ typedef enum _interface_status_t{
     INTERFACE_ERROR,
 } interface_status_t;
 
+/*! \brief Try to connect to the remote interface
+ * 
+ * \return INTERFACE_OK if init was good, INTERFACE_DISCONNECTED if wifi is disconnected
+ *          and INTERFACE_ERROR if connection failed.
+ */
 interface_status_t connect_to_interface(void);
+
+/*! \brief Tell if the interface is currently connected
+ * 
+ * \return true if connected, false if not.
+ */
 bool interface_is_connected(void);
 
 #endif

--- a/hal/sensors/sensors.c
+++ b/hal/sensors/sensors.c
@@ -11,6 +11,22 @@ void init_water_level_sensors(void)
     // IO pin are set as input by default
 }
 
+SHT_measure_t read_temp_humidity(void)
+{
+    float temp, humidity;
+    SHT_measure_t meas;
+    if (SHT3_read_temp_humidity(&temp, &humidity) != SHT_ok) {
+        meas.meas_ok = false;
+        return meas;
+    }
+
+    meas.temp = temp;
+    meas.humidity = humidity;
+    meas.meas_ok = true;
+
+    return meas;
+}
+
 /********** Energy sensors **********/
 #include "ADS7828.h"
 #define ADC_ENERGY_ADDRESS   (ADC_address_0)

--- a/hal/sensors/sensors.h
+++ b/hal/sensors/sensors.h
@@ -4,8 +4,15 @@
 #include <stdint.h>
 #include <stdio.h>
 #include "pico/stdlib.h"
+#include "SHT.h"
 
 void init_water_level_sensors(void);
+
+/*! \brief Read humidity and temperature sensor
+ *
+ * \return Struct containing temperature and humidity as float
+ */
+SHT_measure_t read_temp_humidity(void);
 
 float get_PV_voltage(uint8_t PV_index);
 float get_PV_current(uint8_t PV_index);

--- a/hal/timing/CMakeLists.txt
+++ b/hal/timing/CMakeLists.txt
@@ -3,9 +3,11 @@ add_library(timing
         )
 
 target_link_libraries(timing
+        interface
         hardware_rtc
         wrap_RTC
         wrap_NTP
+        wrap_WATCHDOG
         )
 
 target_include_directories(timing PUBLIC

--- a/hal/timing/timing.c
+++ b/hal/timing/timing.c
@@ -11,8 +11,6 @@ uint8_t init_timer(void)
     if (init_RTC(time) != RTC_OK)
         return TIMING_FAILED;
 
-    init_watchdog();
-
     return TIMING_OK;
 }
 

--- a/hal/timing/timing.c
+++ b/hal/timing/timing.c
@@ -1,6 +1,7 @@
 #include "timing.h"
 
-uint8_t init_timer(void) {
+uint8_t init_timer(void)
+{
     printf("\n----- Getting current date & time -----\n");
     // Get the time online
     datetime_t time;
@@ -10,5 +11,20 @@ uint8_t init_timer(void) {
     if (init_RTC(time) != RTC_OK)
         return TIMING_FAILED;
 
+    init_watchdog();
+
     return TIMING_OK;
+}
+
+void house_keeping(bool init)
+{
+    if (init) {
+        init_watchdog();
+    }
+    feed_watchdog();
+
+    if (interface_is_connected()) {
+        // Send update to the interface
+        
+    }
 }

--- a/hal/timing/timing.h
+++ b/hal/timing/timing.h
@@ -11,7 +11,18 @@ typedef enum _timing_status_t{
     TIMING_FAILED
 } timing_status_t;
 
+/*! \brief Get date&time from the web and init real time clock
+ *
+ * \note Need wifi to do so
+ * 
+ * \return TIMING_OK if init was good, TIMING_FAILED if not
+ */
 uint8_t init_timer(void);
+
+/*! \brief Some house keeping task. (Watchdog, interface ping, etc)
+ * 
+ * \param init True to init the watchdog, false to feed only
+ */
 void house_keeping(bool init);
 
 #endif

--- a/hal/timing/timing.h
+++ b/hal/timing/timing.h
@@ -21,7 +21,7 @@ uint8_t init_timer(void);
 
 /*! \brief Some house keeping task. (Watchdog, interface ping, etc)
  * 
- * \param init True to init the watchdog, false to feed only
+ * \param init True for init, false during normal operation
  */
 void house_keeping(bool init);
 

--- a/hal/timing/timing.h
+++ b/hal/timing/timing.h
@@ -2,7 +2,9 @@
 #define TIMING_H
 
 #include <stdint.h>
+#include "interface.h"
 #include "wrap_RTC.h"
+#include "wrap_WATCHDOG.h"
 
 typedef enum _timing_status_t{
     TIMING_OK,
@@ -10,5 +12,6 @@ typedef enum _timing_status_t{
 } timing_status_t;
 
 uint8_t init_timer(void);
+void house_keeping(bool init);
 
 #endif


### PR DESCRIPTION
Enable et test de watchdog. Utile si le Pi arrete de fonction pour nimporte quel bug. Le watchdog va reset le Pi et se réinitialiser.